### PR TITLE
change to use moduleserve fork instead; note this is demo only;

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "reason-react": ">=0.7.0"
   },
   "devDependencies": {
+    "@divertiseasia/moduleserve": "^0.9.2-alpha.1",
     "@glennsl/bs-jest": "^0.5.0",
     "bs-jest-dom": "^2.0.1",
     "bs-platform": "^7.2.0",
     "bs-react-testing-library": "^0.6.0",
-    "bs-webapi": "^0.15.8",
-    "moduleserve": "github:marijnh/moduleserve#7db414e"
+    "bs-webapi": "^0.15.8"
   }
 }


### PR DESCRIPTION
I'm not 100% sure we should merge this but it resolves demo working when pulling as dev. If someone pulls as dependency it will still have the issue, but it's easier to fix? Long term should revert back to the main fork of moduleserve.